### PR TITLE
Truncate check output  in client modal for dark theme

### DIFF
--- a/public/css/uchiwa-dark/uchiwa-dark.css
+++ b/public/css/uchiwa-dark/uchiwa-dark.css
@@ -302,7 +302,7 @@ hr {
 .list a {
   text-decoration: none; }
 
-.list td.output {
+.list td.check-output {
   text-overflow: ellipsis;
   overflow: hidden;
   max-width: 300px;


### PR DESCRIPTION
- Resolves sensu/uchiwa#57
- It appears the dark theme was not rebuilt after a change was made to the default theme (which it depends on).
