### PR TITLE
Use underscore .each in utilityService

### DIFF
--- a/public/js/services.js
+++ b/public/js/services.js
@@ -15,7 +15,7 @@ serviceModule.factory('socket', function (socketFactory) {
  * Notifications
  */
 serviceModule.provider('notification', function () {
-  this.setOptions = function(options) {
+  this.setOptions = function (options) {
     if (angular.isObject(options)) {
       window.toastr.options = options;
     }
@@ -29,9 +29,20 @@ serviceModule.provider('notification', function () {
 });
 
 /**
+ * Underscore.js
+ */
+serviceModule.factory('underscore', function () {
+  if (angular.isUndefined(window._)) {
+    console.log('underscore.js is required');
+  } else {
+    return window._;
+  }
+});
+
+/**
  * Utility/Helpers
  */
-serviceModule.service('utilityService', function () {
+serviceModule.service('utilityService', ['underscore', function (underscore) {
   // Divide an array into 'n' arrays
   var splitArray = function (array, n) {
     var arrays = [];
@@ -44,12 +55,12 @@ serviceModule.service('utilityService', function () {
   };
 
   this.getRows = function (array, n) {
-    angular.forEach(array, function (element, index, list) {
+    underscore.each(array, function (element, index, list) {
       list[index] = splitArray(element, n);
     });
     return array;
   };
-});
+}]);
 
 /**
  * Toggle
@@ -84,14 +95,14 @@ serviceModule.service('toggleService', function () {
  * Toggle Client
  */
 serviceModule.service('toggleClientService', function () {
-	var toggle = [];
-	this.toggle = toggle;
-	this.toggleOn = function (index) {
-		if (angular.isUndefined(toggle[index])) {
-			toggle[index] = {hidden: false};
-		}
-		toggle[index].hidden = !toggle[index].hidden;
-	};
+  var toggle = [];
+  this.toggle = toggle;
+  this.toggleOn = function (index) {
+    if (angular.isUndefined(toggle[index])) {
+      toggle[index] = {hidden: false};
+    }
+    toggle[index].hidden = !toggle[index].hidden;
+  };
 });
 
 /**

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -5,6 +5,7 @@ module.exports = function(config) {
     frameworks: ['jasmine'],
     files : [
       'public/bower_components/jquery/dist/jquery.js',
+      'public/bower_components/underscore/underscore.js',
       'public/bower_components/angular/angular.js',
       'public/bower_components/angular-cookies/angular-cookies.js',
       'public/bower_components/angular-route/angular-route.js',


### PR DESCRIPTION
- There were changes to Angular's forEach function in v1.2.21 that causes the third "context" argument to be undefined. This will be resolved in a future Angular release.
- Until then, create an underscore service for DI and use underscore's .each function.
- Also, fix a few CS issues in services.js
