### PR TITLE
Add Sass Grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,10 +21,44 @@ module.exports = function (grunt) {
         '<%= settings.lib %>/{,*/}*.js',
         '<%= settings.public %>/js/{,*/}*.js',
       ]
+    },
+    karma: {
+      unit: {
+        configFile: 'test/karma.conf.js'
+      }
+    },
+    sass: {
+      dist: {
+        files: [{
+          expand: true,
+          cwd: '<%= settings.public %>/css',
+          src: ['**/*.scss'],
+          dest: '<%= settings.public %>/css',
+          ext: '.css'
+        }]
+      }
+    },
+    watch: {
+      scss: {
+        files: ['<%= settings.public %>/css/**/*.scss'],
+        tasks: ['sass:dist'],
+        options: {
+          spawn: false
+        }
+      }
     }
   });
 
-  grunt.registerTask('default', [
+  grunt.registerTask('dev', [
+    'watch:scss'
+  ]);
+
+  grunt.registerTask('lint', [
     'newer:jshint'
+  ]);
+
+  grunt.registerTask('default', [
+    'sass',
+    'karma:unit'
   ]);
 };

--- a/package.json
+++ b/package.json
@@ -4,16 +4,12 @@
   "private": true,
   "scripts": {
     "postinstall": "bower --allow-root install",
-
-    "test": "karma start test/karma.conf.js",
-
+    "test": "grunt default",
     "preupdate-webdriver": "npm install",
     "update-webdriver": "webdriver-manager update",
-
     "preprotractor": "npm run update-webdriver",
     "protractor": "protractor test/protractor-conf.js",
     "protractor-debug": "protractor debug test/protractor-conf.js",
-
     "prestart": "npm install",
     "start": "node app.js"
   },
@@ -22,18 +18,20 @@
     "bower": "^1.3.4",
     "ejs": "0.8.*",
     "express": "3.4.*",
-    "grunt": "~0.4.1",
-    "grunt-contrib-jshint": "~0.7.1",
-    "grunt-newer": "~0.6.1",
-    "jshint-stylish": "~0.1.3",
-    "load-grunt-tasks": "~0.4.0",
-    "socket.io": "0.9.*",
     "moment": "2.5.*",
-    "time-grunt": "~0.2.1",
+    "socket.io": "0.9.*",
     "underscore": "1.6.*",
     "yargs": "1.2.*"
   },
   "devDependencies": {
+    "grunt": "~0.4.1",
+    "grunt-contrib-jshint": "~0.7.1",
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-newer": "~0.6.1",
+    "jshint-stylish": "~0.1.3",
+    "load-grunt-tasks": "~0.4.0",
+    "grunt-contrib-sass": "^0.7.3",
+    "time-grunt": "~0.2.1",
     "grunt-karma": "^0.8.2",
     "istanbul": "~0.2.6",
     "karma": "~0.12.0",


### PR DESCRIPTION
- Resolves sensu/uchiwa#62
- The Sass Grunt task can be run with "grunt sass:dist" or the Sass source can be watched/built continuously with "grunt dev"
- The "grunt default" task now runs the Sass build task and the new karma unit test task.
- "npm test" now runs "grunt default" (build Sass -> run unit tests)
- Added a top level jshint task that can be run with "grunt lint"
- Added grunt-contrib-sass and grunt-contrib-watch to make the new grunt tasks possible.
- Also, moved the grunt-related packages to devDependencies in package.json
