### PR TITLE
Fix pill border overflow

### DIFF
--- a/public/css/uchiwa-dark/uchiwa-dark.css
+++ b/public/css/uchiwa-dark/uchiwa-dark.css
@@ -330,7 +330,7 @@ a {
   background-color: inherit;
   border-bottom: 3px solid #5f97fb; 
   margin-bottom: -3px;
-  z-index: :10; }
+  z-index: 10; }
 
 /* Colors */
 /* Body, Sections and Headers */

--- a/public/css/uchiwa-default/uchiwa-default.css
+++ b/public/css/uchiwa-default/uchiwa-default.css
@@ -320,7 +320,7 @@ a {
   background-color: inherit;
   border-bottom: 3px solid #5f97fb; 
   margin-bottom: -3px;
-  z-index: :10; }
+  z-index: 10; }
 
 /* Colors */
 /* Body, Sections and Headers */


### PR DESCRIPTION
When you have many Sensu APIs (more than 10), the data center list wraps but due to the active border, the LI menu doesn't render correctly:

![screen shot 2014-08-26 at 4 02 11 pm](https://cloud.githubusercontent.com/assets/465717/4046483/ada34fc4-2d32-11e4-86d3-13f7b6a30ce6.png)

This change fixes that

![screen shot 2014-08-26 at 6 16 57 pm](https://cloud.githubusercontent.com/assets/465717/4048572/d92a14d6-2d44-11e4-84fd-f5dd2fa8880d.png)

The z-index is used to stop pills popping over the highlighted border when hovered over.
