### PR TITLE
Display the right check model and rich output when check returns 0

### DIFF
--- a/public/partials/client/index.html
+++ b/public/partials/client/index.html
@@ -149,7 +149,7 @@
                     <span class="key pull-right">{{key}}</span>
                   </div>
                   <div class="col-sm-10">
-                    <span class="value">{{value}}</span>
+                    <span class="value" ng-bind-html="value | displayObject | richOutput"></span>
                   </div>
                 </div>
               </span>

--- a/uchiwa/helpers.go
+++ b/uchiwa/helpers.go
@@ -47,7 +47,7 @@ func findModel(id string, dc string) map[string]interface{} {
 			logger.Warningf("Could not assert check interface %+v", k)
 			continue
 		}
-		if m["name"] == id {
+		if m["name"] == id && m["dc"] == dc {
 			return m
 		}
 	}


### PR DESCRIPTION
- When multiple checks have the same name in multiple DC, make sure to compare the dc
- Display rich data even when the check returns 0
