### PR TITLE
Use $interval instead of pollingFactory

### DIFF
--- a/public/js/controllers.js
+++ b/public/js/controllers.js
@@ -5,8 +5,8 @@ var controllerModule = angular.module('uchiwa.controllers', []);
 /**
 * Init
 */
-controllerModule.controller('init', ['$rootScope', '$scope', 'notification', 'pollingFactory', 'Page', 'uchiwaBackend',
-  function ($rootScope, $scope, notification, pollingFactory, Page, uchiwaBackend) {
+controllerModule.controller('init', ['$rootScope', '$scope', '$interval', 'notification', 'Page', 'uchiwaBackend',
+  function ($rootScope, $scope, $interval, notification, Page, uchiwaBackend) {
     $scope.Page = Page;
     $rootScope.skipRefresh = false;
     $rootScope.alerts = [];
@@ -14,10 +14,10 @@ controllerModule.controller('init', ['$rootScope', '$scope', 'notification', 'po
 
     uchiwaBackend.getConfig()
       .success(function (data) {
-        pollingFactory.callFnOnInterval(function () { $rootScope.getSensu(); }, data.Uchiwa.Refresh);
+        $interval($rootScope.getSensu, data.Uchiwa.Refresh * 1000);
       })
       .error(function () {
-        pollingFactory.callFnOnInterval(function () { $rootScope.getSensu(); }, 10);
+        $interval($rootScope.getSensu, 10000);
       });
 
     $rootScope.getSensu = function () {

--- a/public/js/factories.js
+++ b/public/js/factories.js
@@ -14,22 +14,6 @@ factoryModule.factory('Page', function() {
 });
 
 /**
-* Polling
-*/
-factoryModule.factory('pollingFactory', function($rootScope, $timeout) {
-  function callFnOnInterval(fn, timeInterval) {
-    var promise = $timeout(fn, timeInterval*1000);
-    return promise.then(function(){
-      callFnOnInterval(fn, timeInterval);
-    });
-  }
-
-  return {
-    callFnOnInterval: callFnOnInterval
-  };
-});
-
-/**
 * Underscore.js
 */
 factoryModule.factory('underscore', function () {


### PR DESCRIPTION
Replaces the pollingFactory with Angular's `$interval` service. Reduces LOC & it seems necessary as per the Protractor documentation:

```
Before performing any action, Protractor asks Angular to wait until the page is 
synchronized. This means that all timeouts and http requests are finished. If 
your application continuously polls $timeout or $http, it will never be registered 
as completely loaded. You should use the $interval service (interval.js) for 
anything that polls continuously (introduced in Angular 1.2rc3).
```

Source: https://github.com/angular/protractor/blob/master/docs/timeouts.md
