### PR TITLE
Added htpasswd auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Make a config.json file for the application, and then launch the uchiwa containe
 ### uchiwa
 - `host` - String: The address on which Uchiwa will listen. The default value is *0.0.0.0*.
 - `port` - Integer: The port on which Uchiwa will listen. The default value is *3000*.
+- `auth` - String: Auth type. Valid values: None, Simple (will use `user` and `pass` for creds), Htpasswd.
+- `Authfile` - String: Path to the htpasswd file. Currently only supported password enryption is SHA1. Used only if auth type is *htpasswd*, ignored otherwise.
 - `user` - String: The username of the Uchiwa dashboard. Leave empty for none.
 - `pass` - String: The password of the Uchiwa dashboard. Leave empty for none.
 - `refresh` - Integer: Determines the interval to pull the Sensu APIs, in seconds. The default value is *5*.

--- a/config.json.example
+++ b/config.json.example
@@ -20,6 +20,7 @@
   "uchiwa": {
     "host": "0.0.0.0",
     "port": 3000,
+    "auth": "simple",
     "user": "admin",
     "pass": "secret",
     "refresh": 5

--- a/uchiwa/auth.go
+++ b/uchiwa/auth.go
@@ -1,0 +1,70 @@
+package uchiwa
+
+import (
+	"net/http"
+	"strings"
+	"crypto/sha1"
+	"encoding/base64"
+	"github.com/palourde/logger"
+)
+
+type Auth struct {
+	Type string
+	Users map[string]string
+}
+
+func (a *Auth) httpauth() func(http.Handler) http.Handler {
+	switch a.Type {
+		case "simple":
+			for k, v :=range a.Users {
+				return SimpleBasicAuth(k,v)
+			}
+		case "htpasswd":
+			fn := func(u,p string) bool {
+				requiredPass, exists := a.Users[u]
+				if !exists {
+					logger.Warningf("No entry for %s.", u)
+					return false
+				}
+				if requiredPass[:5] == "{SHA}" {
+					d := sha1.New()
+					d.Write([]byte(p))
+					if requiredPass[5:] == base64.StdEncoding.EncodeToString(d.Sum(nil)) {
+						return true
+					}
+				} else {
+					logger.Warningf("Invalid htpasswd entry for %s. Must be a SHA entry.", u)
+				}
+				return false
+			}
+			opts := AuthOptions{
+				Realm: "Restricted",
+				AuthFunc: fn,
+			}
+			return CustomBasicAuth(opts)
+	}
+	// no auth by default
+	fn := func(h http.Handler) http.Handler {
+		return h
+	}
+	return fn
+}
+
+type Authenticate interface {
+	httpauth() func(http.Handler) http.Handler
+}
+
+func authType(c *Config) Authenticate {
+	a := new(Auth)
+	a.Type = c.Uchiwa.Auth
+
+	switch strings.ToLower(c.Uchiwa.Auth) {
+		case "simple":
+			users := make(map[string]string,1)
+			users[c.Uchiwa.User] = c.Uchiwa.Pass
+			a.Users = users
+		case "htpasswd":
+			a.Users = c.Uchiwa.Users
+	}
+	return a
+}

--- a/uchiwa/basic_auth.go
+++ b/uchiwa/basic_auth.go
@@ -1,0 +1,136 @@
+package uchiwa
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type basicAuth struct {
+	h    http.Handler
+	opts AuthOptions
+}
+
+// AuthOptions stores the configuration for HTTP Basic Authentication.
+//
+// A http.Handler may also be passed to UnauthorizedHandler to override the
+// default error handler if you wish to serve a custom template/response.
+type AuthOptions struct {
+	Realm               string
+	AuthFunc            func(string, string) bool
+	UnauthorizedHandler http.Handler
+}
+
+// Satisfies the http.Handler interface for basicAuth.
+func (b basicAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Check if we have a user-provided error handler, else set a default
+	if b.opts.UnauthorizedHandler == nil {
+		b.opts.UnauthorizedHandler = http.HandlerFunc(defaultUnauthorizedHandler)
+	}
+
+	// Check that the provided details match
+	if b.authenticate(r) == false {
+		b.requestAuth(w, r)
+		return
+	}
+
+	// Call the next handler on success.
+	b.h.ServeHTTP(w, r)
+}
+
+// authenticate retrieves and then validates the user:password combination provided in
+// the request header. Returns 'false' if the user has not successfully authenticated.
+func (b *basicAuth) authenticate(r *http.Request) bool {
+	const basicScheme string = "Basic "
+
+	// Confirm the request is sending Basic Authentication credentials.
+	auth := r.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, basicScheme) {
+		return false
+	}
+
+	// Get the plain-text username and password from the request
+	// The first six characters are skipped - e.g. "Basic ".
+	str, err := base64.StdEncoding.DecodeString(auth[len(basicScheme):])
+	if err != nil {
+		return false
+	}
+
+	// Split on the first ":" character only, with any subsequent colons assumed to be part
+	// of the password. Note that the RFC2617 standard does not place any limitations on
+	// allowable characters in the password.
+	creds := bytes.SplitN(str, []byte(":"), 2)
+
+	if len(creds) != 2 {
+		return false
+	}
+
+	givenUser := string(creds[0])
+	givenPass := string(creds[1])
+
+    return b.opts.AuthFunc(givenUser, givenPass)
+}
+
+// Require authentication, and serve our error handler otherwise.
+func (b *basicAuth) requestAuth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Basic realm=%q`, b.opts.Realm))
+	b.opts.UnauthorizedHandler.ServeHTTP(w, r)
+}
+
+// defaultUnauthorizedHandler provides a default HTTP 401 Unauthorized response.
+func defaultUnauthorizedHandler(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+}
+
+
+func CustomBasicAuth(opts AuthOptions) func(http.Handler) http.Handler {
+	fn := func(h http.Handler) http.Handler {
+		return basicAuth{h, opts}
+	}
+	return fn
+}
+
+// SimpleBasicAuth is a convenience wrapper around CustomBasicAuth. It takes a user and password, and
+// returns a pre-configured BasicAuth handler using the "Restricted" realm and a default 401 handler.
+//
+func SimpleBasicAuth(user, password string) func(http.Handler) http.Handler {
+
+	fn := func(u, p string) bool {
+		requiredUser := sha256.Sum256([]byte(user))
+		requiredPass := sha256.Sum256([]byte(password))
+
+		// Equalize lengths of supplied and required credentials
+		// by hashing them
+		givenUser := sha256.Sum256([]byte(u))
+		givenPass := sha256.Sum256([]byte(p))
+
+		// Compare the supplied credentials to those set in our options
+		if subtle.ConstantTimeCompare(givenUser[:], requiredUser[:]) == 1 &&
+			subtle.ConstantTimeCompare(givenPass[:], requiredPass[:]) == 1 {
+			return true
+		}
+		return false
+	}
+
+	opts := AuthOptions{
+		Realm: "Restricted",
+		AuthFunc: fn,
+	}
+
+	return CustomBasicAuth(opts)
+}
+
+// dummy example
+
+func DummyBasicAuth() func(http.Handler) http.Handler {
+	opts := AuthOptions{
+		Realm: "Restricted",
+		AuthFunc: func(u,p string) bool { return true },
+	}
+
+	return CustomBasicAuth(opts)
+}


### PR DESCRIPTION
- Redesigned the auth parts of the code to support additional auth mechanisms
- Support for htpasswd flat-file user database

I had to adjust the github.com/goji/httpauth to support a custom auth function. I will create a PR for that project too and in case it get merged we can switch back to the original library.


