### PR TITLE
Filter silenced client events

### DIFF
--- a/uchiwa/events.go
+++ b/uchiwa/events.go
@@ -71,6 +71,9 @@ func BuildEvents() {
 
 		// determine if the event is acknowledged
 		m["acknowledged"] = isAcknowledged(clientName, checkName, dcName)
+        
+		// detertermine if the client is acknowledged
+		m["client"].(map[string]interface{})["acknowledged"] = isAcknowledged(clientName, "", dcName)
 	}
 }
 


### PR DESCRIPTION
This PR is required by https://github.com/sensu/uchiwa-web/pull/12 and is related to https://github.com/sensu/uchiwa/issues/264

This PR creates a new property on events, client.acknowleged, which indicates the silence status of the event's source (client).