### PR TITLE
Firefox does not load favicon.png at the location specified. Instead …

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
   <meta name="description" content="">
   <meta name="author" content="">
 
-  <link rel="icon" type="image/png" href="bower_components/uchiwa-web/img/favicon.png">
+  <link rel="icon" type="image/x-icon" href="bower_components/uchiwa-web/favicon.ico">
 
   <title ng-bind="titleFactory.get()">uchiwa</title>
 


### PR DESCRIPTION
Firefox tries to load /favicon.ico instead of the icon specified in index.html.
```
192.168.11.237 - - [13/Aug/2015:10:56:24 -0400] "GET /favicon.ico HTTP/1.1" 404 19 "-" "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:39.0) Gecko/20100101 Firefox/39.0" "-"
```

By specifying the type of image/x-icon and setting the href to bower_components/uchiwa-web/favicon.ico you get the icon to load correctly in Firefox (and other browsers).
```
192.168.5.135 - - [13/Aug/2015:14:45:47 -0400] "GET /bower_components/uchiwa-web/favicon.ico HTTP/1.1" 200 1342 "-" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:40.0) Gecko/20100101 Firefox/40.0" "-"
```