### PR TITLE
Support the use of static RSA keys for JWT signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ build
 coverage.out
 *.swp
 keys/
+*.rsa
+*.rsa.pub

--- a/uchiwa.go
+++ b/uchiwa.go
@@ -25,8 +25,8 @@ func main() {
 
 	u := uchiwa.Init(config)
 
-	authentication := auth.New()
-	if config.Uchiwa.Auth == "simple" {
+	authentication := auth.New(config.Uchiwa.Auth)
+	if config.Uchiwa.Auth.Driver == "simple" {
 		authentication.Simple(config.Uchiwa.Users)
 	} else {
 		authentication.None()

--- a/uchiwa/auth/auth.go
+++ b/uchiwa/auth/auth.go
@@ -1,8 +1,11 @@
 package auth
 
+import "github.com/sensu/uchiwa/uchiwa/structs"
+
 // Config struct contains the authentication configuration
 type Config struct {
-	Driver     loginFn
+	Auth       structs.Auth
+	DriverFn   loginFn
 	DriverName string
 }
 
@@ -22,35 +25,37 @@ type User struct {
 type loginFn func(string, string) (*User, error)
 
 var (
-	users      []User
+	users []User
 )
 
 // New function initalizes and returns a Config struct
-func New() Config {
-	a := Config{}
+func New(auth structs.Auth) Config {
+	a := Config{
+		Auth: auth,
+	}
 	return a
 }
 
 // None function sets the Config struct in order to disable authentication
 func (a *Config) None() {
-	a.Driver = none
+	a.DriverFn = none
 	a.DriverName = "none"
 }
 
 // Simple function sets the Config struct in order to enable simple authentication based on provided user and pass
 func (a *Config) Simple(u []User) {
-	a.Driver = simple
+	a.DriverFn = simple
 	a.DriverName = "simple"
 
 	users = u
 
-	initToken()
+	initToken(a.Auth)
 }
 
 // Advanced function allows a third party Identification driver
 func (a *Config) Advanced(driver loginFn, driverName string) {
-	a.Driver = driver
+	a.DriverFn = driver
 	a.DriverName = driverName
 
-	initToken()
+	initToken(a.Auth)
 }

--- a/uchiwa/auth/token.go
+++ b/uchiwa/auth/token.go
@@ -3,16 +3,18 @@ package auth
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/sensu/uchiwa/uchiwa/logger"
+	"github.com/sensu/uchiwa/uchiwa/structs"
 )
 
 var (
-	keyPEM    []byte
-	pubKeyPEM []byte
+	privateKey *rsa.PrivateKey
+	publicKey  *rsa.PublicKey
 )
 
 // GetToken returns a string that contain the token
@@ -20,25 +22,70 @@ func GetToken(role *Role, username string) (string, error) {
 	t := jwt.New(jwt.GetSigningMethod("RS256"))
 	t.Claims["Role"] = role
 	t.Claims["Username"] = username
-	tokenString, err := t.SignedString(keyPEM)
+	tokenString, err := t.SignedString(privateKey)
 	return tokenString, err
 }
 
-func initToken() {
-	keyPair, err := rsa.GenerateKey(rand.Reader, 1024)
-	if err != nil {
-		logger.Fatalf("Could not generate the private key: %s", err)
+// generateToken generates a private and public RSA keys
+// in order to be used for the JWT signature
+func generateToken() {
+	privateKey = generateKeyPair()
+	// Precompute some calculations
+	privateKey.Precompute()
+	publicKey = &privateKey.PublicKey
+}
+
+// loadToken loads a private and public RSA keys from the filesystem
+// in order to be used for the JWT signature
+func loadToken(a structs.Auth) error {
+	logger.Debug("Attempting to load the RSA keys from the filesystem")
+
+	if a.PrivateKey == "" || a.PublicKey == "" {
+		return errors.New("The paths to the private and public RSA keys were not provided")
 	}
-	keyPEM = pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(keyPair),
-	})
-	pubKeyANS1, err := x509.MarshalPKIXPublicKey(&keyPair.PublicKey)
+
+	// Read the files from the filesystem
+	prv, err := ioutil.ReadFile(a.PrivateKey)
 	if err != nil {
-		logger.Fatalf("Could not generate the public key: %s", err)
+		return fmt.Errorf("Unable to open the private key file: %v", err)
 	}
-	pubKeyPEM = pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PUBLIC KEY",
-		Bytes: pubKeyANS1,
-	})
+	pub, err := ioutil.ReadFile(a.PublicKey)
+	if err != nil {
+		return fmt.Errorf("Unable to open the public key file: %v", err)
+	}
+
+	// Parse the RSA keys
+	privateKey, err = jwt.ParseRSAPrivateKeyFromPEM(prv)
+	if err != nil {
+		return fmt.Errorf("Unable to parse the private key: %v", err)
+	}
+	publicKey, err = jwt.ParseRSAPublicKeyFromPEM(pub)
+	if err != nil {
+		return fmt.Errorf("Unable to parse the public key: %v", err)
+	}
+
+	logger.Info("Provided RSA keys successfully loaded")
+	return nil
+}
+
+// initToken initializes the token by weither loading the keys from the
+// filesystem with the loadToken() function or by generating temporarily
+// ones with the generateToken() function
+func initToken(a structs.Auth) {
+	err := loadToken(a)
+	if err != nil {
+		logger.Debug(err)
+		logger.Debug("Generating new temporary RSA keys")
+		generateToken()
+	}
+}
+
+// generateKeyPair generates an RSA keypair of 2048 bits using a random rand.Reader
+func generateKeyPair() *rsa.PrivateKey {
+	keypair, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		logger.Fatalf("Could not generate an RSA keypair: %s", err)
+	}
+
+	return keypair
 }

--- a/uchiwa/config/config.go
+++ b/uchiwa/config/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sensu/uchiwa/uchiwa/auth"
 	"github.com/sensu/uchiwa/uchiwa/logger"
+	"github.com/sensu/uchiwa/uchiwa/structs"
 )
 
 // Config struct contains []SensuConfig and UchiwaConfig structs
@@ -41,7 +42,7 @@ type GlobalConfig struct {
 	User       string
 	Users      []auth.User
 	Audit      Audit
-	Auth       string
+	Auth       structs.Auth
 	Db         Db
 	Enterprise bool
 	Github     Github
@@ -156,9 +157,9 @@ func (c *Config) initUchiwa() {
 
 	// authentication
 	if c.Uchiwa.Github.Server != "" {
-		c.Uchiwa.Auth = "github"
+		c.Uchiwa.Auth.Driver = "github"
 	} else if c.Uchiwa.Ldap.Server != "" {
-		c.Uchiwa.Auth = "ldap"
+		c.Uchiwa.Auth.Driver = "ldap"
 		if c.Uchiwa.Ldap.Port == 0 {
 			c.Uchiwa.Ldap.Port = 389
 		}
@@ -185,13 +186,13 @@ func (c *Config) initUchiwa() {
 		}
 
 	} else if c.Uchiwa.Db.Driver != "" && c.Uchiwa.Db.Scheme != "" {
-		c.Uchiwa.Auth = "sql"
+		c.Uchiwa.Auth.Driver = "sql"
 	} else if len(c.Uchiwa.Users) != 0 {
 		logger.Debug("Loading multiple users from the config")
-		c.Uchiwa.Auth = "simple"
+		c.Uchiwa.Auth.Driver = "simple"
 	} else if c.Uchiwa.User != "" && c.Uchiwa.Pass != "" {
 		logger.Debug("Loading single user from the config")
-		c.Uchiwa.Auth = "simple"
+		c.Uchiwa.Auth.Driver = "simple"
 		c.Uchiwa.Users = append(c.Uchiwa.Users, auth.User{Username: c.Uchiwa.User, Password: c.Uchiwa.Pass, FullName: c.Uchiwa.User})
 	}
 

--- a/uchiwa/config/config_test.go
+++ b/uchiwa/config/config_test.go
@@ -42,7 +42,7 @@ func TestLoadArrayOfUsers(t *testing.T) {
 	assert.Nil(t, err, "got unexpected error: %s", err)
 	assert.NotNil(t, conf, "conf should not be nil")
 
-	assert.Equal(t, "simple", conf.Uchiwa.Auth, "Uchiwa Auth should be simple")
+	assert.Equal(t, "simple", conf.Uchiwa.Auth.Driver, "Uchiwa authentication driver should be 'simple'")
 	assert.Equal(t, 2, len(conf.Uchiwa.Users))
 }
 
@@ -51,7 +51,7 @@ func TestLoadArrayOfUsersOnPublicGet(t *testing.T) {
 	assert.Nil(t, err, "got unexpected error: %s", err)
 	assert.NotNil(t, conf, "conf should not be nil")
 
-	assert.Equal(t, "simple", conf.Uchiwa.Auth, "Uchiwa Auth should be simple")
+	assert.Equal(t, "simple", conf.Uchiwa.Auth.Driver, "Uchiwa authentication driver should be 'simple'")
 	public := conf.GetPublic()
 	assert.Equal(t, 0, len(public.Uchiwa.Users))
 }

--- a/uchiwa/server.go
+++ b/uchiwa/server.go
@@ -223,7 +223,7 @@ func (u *Uchiwa) configHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		if resources[2] == "auth" {
-			fmt.Fprintf(w, "%s", u.PublicConfig.Uchiwa.Auth)
+			fmt.Fprintf(w, "%s", u.PublicConfig.Uchiwa.Auth.Driver)
 		} else {
 			http.Error(w, "", http.StatusNotFound)
 			return

--- a/uchiwa/structs/structs.go
+++ b/uchiwa/structs/structs.go
@@ -13,6 +13,14 @@ type AuditLog struct {
 	User       string    `json:"user"`
 }
 
+// Auth struct contains the generic configuration and details
+// about the authentication
+type Auth struct {
+	Driver     string
+	PrivateKey string
+	PublicKey  string
+}
+
 // Data is a structure for holding public data fetched from the Sensu APIs and exposed by the endpoints
 type Data struct {
 	Aggregates    []interface{}


### PR DESCRIPTION
Fix https://github.com/sensu/uchiwa/issues/394

- Load the RSA keys provided in the config file (TODO: docs). Fallback to automatic generation in case of problems.
- Fix a [vulnerability](https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/) in the JWT library
- Upgrade to 2048 RSA keys for JWT signature