### PR TITLE
Add support for crypt()ed passwords.

### DIFF
--- a/uchiwa/auth/drivers.go
+++ b/uchiwa/auth/drivers.go
@@ -1,6 +1,15 @@
 package auth
 
-import "fmt"
+import (
+    "fmt"
+    "strings"
+    "github.com/kless/osutil/user/crypt"
+)
+
+import _ "github.com/kless/osutil/user/crypt/apr1_crypt"
+import _ "github.com/kless/osutil/user/crypt/md5_crypt"
+import _ "github.com/kless/osutil/user/crypt/sha256_crypt"
+import _ "github.com/kless/osutil/user/crypt/sha512_crypt"
 
 func none(u, p string) (*User, error) {
 	return &User{}, nil
@@ -8,9 +17,18 @@ func none(u, p string) (*User, error) {
 
 func simple(u, p string) (*User, error) {
 	for _, user := range users {
-		if u == user.Username && p == user.Password {
-			return &user, nil
-		}
+        if u != user.Username {
+            continue
+        }
+        if strings.HasPrefix(user.Password, "{crypt}") {
+            password := user.Password;
+            password = strings.Replace(password, "{crypt}", "", 1);
+            return &user, crypt.NewFromHash(password).Verify(password, []byte(p));
+        } else {
+            if p == user.Password {
+                return &user, nil;
+            }
+        }
 	}
 	return &User{}, fmt.Errorf("invalid user '%s' or invalid password", u)
 }

--- a/uchiwa/auth/drivers_test.go
+++ b/uchiwa/auth/drivers_test.go
@@ -1,0 +1,38 @@
+package auth;
+
+
+import (
+    "testing"
+    "github.com/stretchr/testify/assert"
+)
+
+
+func TestAuthSimplePlain(t *testing.T) {
+
+    users = []User{};
+
+    user, err := simple("admin", "test");
+    assert.Equal(t, &User{}, user);
+    assert.NotNil(t, err);
+
+    admin := User{Username: "admin", Password: "test"};
+    users = append(users, admin);
+
+    user, err = simple("admin", "test");
+    assert.Equal(t, "admin", user.Username);
+    assert.Nil(t, err);
+
+    user, err = simple("admin", "testwrong");
+    assert.Equal(t, &User{}, user);
+    assert.NotNil(t, err);
+
+    admin.Password = "$6$rounds=1000$$vDKCc9rOGoJbVpjMvQImrBCbdha0O.xOzDOISi93TtOhw50y5pfOawbWUBl/.bvAQ9GYV3/rTXJemXg429BHy/";
+    user, err = simple("admin", "test");
+    assert.Equal(t, "admin", user.Username);
+    assert.Nil(t, err);
+
+    user, err = simple("admin", "testwrong");
+    assert.Equal(t, &User{}, user);
+    assert.NotNil(t, err);
+
+}


### PR DESCRIPTION
Fixes #448.

Also adds a thin test layer for the affected code.

This is the first Go code I ever wrote. Please bear with me. :)

A few questions:

- is the new dependency fine?
- is the test ok?

Also, I'm using the more or less widely known {crypt} prefix to indicate we should treat a password as crypted. I see that the user data structure has a separate field for a hashed/salted password, but this a) looks like it has implications to the Enterprise edition and b) I didn't want to make too much of an invasive change.

Let me know if this needs changes or is otherwise not good enough. 

Cheers,
Christian