### PR TITLE
Fix for infinite loop in getSlice()

### DIFF
--- a/uchiwa/sensu/methods.go
+++ b/uchiwa/sensu/methods.go
@@ -74,6 +74,10 @@ func (api *API) getSlice(endpoint string, limit int) ([]interface{}, error) {
 				return nil, fmt.Errorf("Could not parse the JSON-encoded response body: %v", err)
 			}
 
+			if len(partialList) == 0 {
+				break
+			}
+
 			for _, e := range partialList {
 				list = append(list, e)
 			}


### PR DESCRIPTION
Fixes an infinite loop in getSlice() by breaking out of the for loop if the most recent iteration returned zero new elements. See https://github.com/sensu/uchiwa/issues/438 for a more in-depth discussion.