### PR TITLE
Overwrite silence & silenced_by attributes in Sensu events. Fixes #602

### DIFF
--- a/uchiwa/daemon/events.go
+++ b/uchiwa/daemon/events.go
@@ -13,42 +13,46 @@ func (d *Daemon) buildEvents() {
 		m := e.(map[string]interface{})
 
 		// get client name
-		c, ok := m["client"].(map[string]interface{})
+		clientMap, ok := m["client"].(map[string]interface{})
 		if !ok {
-			logger.Warningf("Could not assert event's client interface from %+v", c)
+			logger.Warningf("Could not assert event's client interface from %+v", clientMap)
 			continue
 		}
 
-		clientName, ok := c["name"].(string)
+		client, ok := clientMap["name"].(string)
 		if !ok {
-			logger.Warningf("Could not assert event's client name from %+v", c)
+			logger.Warningf("Could not assert event's client name from %+v", clientMap)
 			continue
 		}
 
 		// get check name
-		k, ok := m["check"].(map[string]interface{})
+		checkMap, ok := m["check"].(map[string]interface{})
 		if !ok {
-			logger.Warningf("Could not assert event's check interface from %+v", k)
+			logger.Warningf("Could not assert event's check interface from %+v", checkMap)
 			continue
 		}
 
-		checkName, ok := k["name"].(string)
+		check, ok := checkMap["name"].(string)
 		if !ok {
-			logger.Warningf("Could not assert event's check name from %+v", k)
+			logger.Warningf("Could not assert event's check name from %+v", checkMap)
 			continue
 		}
 
 		// get dc name
-		dcName, ok := m["dc"].(string)
+		dc, ok := m["dc"].(string)
 		if !ok {
 			logger.Warningf("Could not assert event's datacenter name from %+v", m)
 			continue
 		}
 
 		// Set the event unique ID
-		m["_id"] = fmt.Sprintf("%s/%s/%s", dcName, clientName, checkName)
+		m["_id"] = fmt.Sprintf("%s/%s/%s", dc, client, check)
 
-		// detertermine if the client is acknowledged
-		m["client"].(map[string]interface{})["silenced"] = helpers.IsClientSilenced(clientName, dcName, d.Data.Silenced)
+		// Determine if the client is silenced
+		m["client"].(map[string]interface{})["silenced"] = helpers.IsClientSilenced(client, dc, d.Data.Silenced)
+
+		// Determine if the check is silenced.
+		// See https://github.com/sensu/uchiwa/issues/602
+		m["silenced"], m["silenced_by"] = helpers.IsCheckSilenced(checkMap, client, dc, d.Data.Silenced)
 	}
 }


### PR DESCRIPTION
## Description
Do not trust the `silenced` & `silenced_by` attributes provided in Sensu events since they might be confusing for the users.

## Related Issue
https://github.com/sensu/uchiwa/issues/602

## How Has This Been Tested?
We already use the `helpers.IsCheckSilenced` function for the client view.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

