### PR TITLE
Issue #618 fix

### DIFF
--- a/uchiwa/logger/logger.go
+++ b/uchiwa/logger/logger.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"html"
 )
 
 // Logging Levels
@@ -84,7 +85,7 @@ func (l *Logger) print(level string, format string, args ...interface{}) {
 
 	data, err := json.Marshal(l)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Println(html.EscapeString(err))
 		return
 	}
 	fmt.Println(string(data))

--- a/uchiwa/logger/logger.go
+++ b/uchiwa/logger/logger.go
@@ -85,7 +85,7 @@ func (l *Logger) print(level string, format string, args ...interface{}) {
 
 	data, err := json.Marshal(l)
 	if err != nil {
-		fmt.Println(html.EscapeString(err))
+		fmt.Println(html.EscapeString(err.Error()))
 		return
 	}
 	fmt.Println(string(data))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added `html.EscapeString()` to `fmt.Println(err.Error())`. This change may also be appropriate for `fmt.Println(string(data))` but would warrant testing I'm not prepared/setup to do.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #618 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prevents 2 potential reflected XSS points identified by Fortify

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
logger.go was built locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
