### PR TITLE
remove race condition on logger package

### DIFF
--- a/uchiwa/logger/logger.go
+++ b/uchiwa/logger/logger.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"sync"
 )
 
 // Logging Levels
@@ -36,7 +37,10 @@ type Source struct {
 	Line int    `json:"line,omitempty"`
 }
 
-var log = new(Logger)
+var (
+		log = new(Logger)
+		logMutex = &sync.Mutex{}
+)
 
 func init() {
 	configuredLevel = INFO
@@ -68,6 +72,9 @@ func (l *Logger) now() {
 }
 
 func (l *Logger) print(level string, format string, args ...interface{}) {
+	logMutex.Lock()
+	defer logMutex.Unlock()
+
 	l.now()
 	l.Message = l.message(format, args)
 	l.Level = &level

--- a/uchiwa/logger/logger.go
+++ b/uchiwa/logger/logger.go
@@ -3,11 +3,11 @@ package logger
 import (
 	"encoding/json"
 	"fmt"
-  "html"
+	"html"
 	"os"
 	"runtime"
 	"strings"
-  "sync"
+	"sync"
 	"time"
 )
 

--- a/uchiwa/logger/logger_test.go
+++ b/uchiwa/logger/logger_test.go
@@ -2,9 +2,47 @@ package logger
 
 import (
 	"testing"
+	"regexp"
+	"sync"
+	"fmt"
+	"io/ioutil"
+	"os"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestLogPrint( t *testing.T) {
+	var waitGroup sync.WaitGroup
+	go_routine_count := 100
+	originalStdout := os.Stdout
+	read, write, _ := os.Pipe()
+	os.Stdout = write
+
+	// run go routines that each make a call
+	// to the log.print function and print
+	// a unique string
+	for i := 0; i < go_routine_count; i++ {
+		waitGroup.Add(1)
+		go func(counter int) {
+			defer waitGroup.Done()
+			log.print("info", fmt.Sprintf("At counter %d.", counter))
+		}(i)
+	}
+
+	waitGroup.Wait()
+
+	write.Close()
+	output, _ := ioutil.ReadAll(read)
+
+	os.Stdout = originalStdout
+
+	// check for each of the 
+	// unique strings printed 
+	// by the go routines
+	for j := 0; j < go_routine_count; j++ {
+		assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("At counter %d", j)), string(output))
+	}
+}
 
 func TestGetLevelInt(t *testing.T) {
 	integer := getLevelInt("Trace")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implements a mutex in the logger package to control access to the main Logger object used in the `print` function.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#621 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Removes the race condition reported in #621 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've ran both my new and existing tests and ensured that they all pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
