### PR TITLE
Add support for editing the Sensu client registry

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,7 @@
   <link href="bower_components/angular-toastr/dist/angular-toastr.min.css?rel=1489178318313" rel="stylesheet">
   <link href="bower_components/highlightjs/styles/tomorrow.css?rel=1489178318313" rel="stylesheet">
   <link href="bower_components/moment-picker/dist/angular-moment-picker.min.css?rel=1489178318312" rel="stylesheet">
+  <link href="bower_components/jsoneditor/dist/jsoneditor.min.css?rel=1489178318312" rel="stylesheet">
 
   <!-- Uchiwa CSS -->
   <link href="bower_components/uchiwa-web/css/uchiwa-default/uchiwa-default.css?rel=1489178318313" rel="stylesheet" site-theme>
@@ -51,6 +52,8 @@
 <script src="bower_components/angular-moment/angular-moment.min.js?rel=1489178318312"></script>
 <script src="bower_components/moment-picker/dist/angular-moment-picker.min.js?rel=1489178318312"></script>
 <script src="bower_components/angular-gravatar/build/angular-gravatar.min.js?rel=1489178318312"></script>
+<script src="bower_components/jsoneditor/dist/jsoneditor.min.js?rel=1489178318313"></script>
+<script src="bower_components/ng-jsoneditor/ng-jsoneditor.js?rel=1489178318313"></script>
 <script src="bower_components/ua-parser-js/dist/ua-parser.min.js?rel=1489178318313"></script>
 
 <!-- Uchiwa JS -->

--- a/uchiwa/client.go
+++ b/uchiwa/client.go
@@ -156,3 +156,28 @@ func (u *Uchiwa) GetClientHistory(dc, name string) ([]interface{}, error) {
 
 	return history, nil
 }
+
+func (u *Uchiwa) UpdateClient(payload interface{}) error {
+	client, ok := payload.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("Unable to decode the payload")
+	}
+
+	dc, ok := client["dc"].(string)
+	if !ok {
+		return fmt.Errorf("Unable to identify the datacenter")
+	}
+
+	api, err := getAPI(u.Datacenters, dc)
+	if err != nil {
+		logger.Warning(err)
+		return err
+	}
+
+	_, err = api.UpdateClient(payload)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/uchiwa/filters/filters.go
+++ b/uchiwa/filters/filters.go
@@ -9,6 +9,7 @@ import (
 type Filters interface {
 	Aggregates(*[]interface{}, *jwt.Token) []interface{}
 	Checks(*[]interface{}, *jwt.Token) []interface{}
+	Client(interface{}, *jwt.Token) bool
 	Clients(*[]interface{}, *jwt.Token) []interface{}
 	Datacenters([]*structs.Datacenter, *jwt.Token) []*structs.Datacenter
 	Events(*[]interface{}, *jwt.Token) []interface{}
@@ -34,6 +35,11 @@ func (u *Uchiwa) Checks(data *[]interface{}, token *jwt.Token) []interface{} {
 	checks := make([]interface{}, len(*data))
 	copy(checks, *data)
 	return checks
+}
+
+// Client is a function that filters GET requests.
+func (u *Uchiwa) Client(data interface{}, token *jwt.Token) bool {
+	return true
 }
 
 // Clients filters based on role's datacenters and subscriptions

--- a/uchiwa/sensu/clients.go
+++ b/uchiwa/sensu/clients.go
@@ -1,6 +1,14 @@
 package sensu
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DeleteClient deletes a client using its name
+func (s *Sensu) DeleteClient(client string) error {
+	return s.delete(fmt.Sprintf("clients/%s", client))
+}
 
 // GetClients returns a slice of all clients
 func (s *Sensu) GetClients() ([]interface{}, error) {
@@ -17,7 +25,11 @@ func (s *Sensu) GetClientHistory(client string) ([]interface{}, error) {
 	return s.getSlice(fmt.Sprintf("clients/%s/history", client), NoLimit)
 }
 
-// DeleteClient deletes a client using its name
-func (s *Sensu) DeleteClient(client string) error {
-	return s.delete(fmt.Sprintf("clients/%s", client))
+func (s *Sensu) UpdateClient(payload interface{}) (map[string]interface{}, error) {
+	payloadstr, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("Error while parsing the payload: %s", err)
+	}
+
+	return s.postPayload(fmt.Sprintf("clients"), string(payloadstr[:]))
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows editing of proxy clients through the Sensu client registry, directly from the UI. Only applies to clients with `keepalives:false`.

## Related Issue
Fixes https://github.com/sensu/uchiwa/issues/651.
Depends on https://github.com/sensu/uchiwa-web/pull/144

## Motivation and Context
Be able to easily modify proxy clients.

## How Has This Been Tested?
Unit tests & manual testing.

## Screenshots (if appropriate):
![screen shot 2017-03-23 at 09 24 41](https://cloud.githubusercontent.com/assets/4105580/24249692/98a0d4d6-0faa-11e7-8758-3617f31fc118.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
