### PR TITLE
Add a datacenter view to access information about the Sensu servers

### DIFF
--- a/uchiwa/daemon/daemon.go
+++ b/uchiwa/daemon/daemon.go
@@ -80,36 +80,43 @@ func (d *Daemon) fetchData() {
 		// fetch sensu data from the datacenter
 		stashes, err := datacenter.GetStashes()
 		if err != nil {
+			logger.Debug(err)
 			logger.Warningf("Connection failed to the datacenter %s", datacenter.Name)
 			continue
 		}
 		silenced, err := datacenter.GetSilenced()
 		if err != nil {
+			logger.Debug(err)
 			logger.Warningf("Impossible to retrieve silenced entries from the "+
 				"datacenter %s. Silencing might not be possible, please update Sensu", datacenter.Name)
 		}
 		checks, err := datacenter.GetChecks()
 		if err != nil {
+			logger.Debug(err)
 			logger.Warningf("Connection failed to the datacenter %s", datacenter.Name)
 			continue
 		}
 		clients, err := datacenter.GetClients()
 		if err != nil {
+			logger.Debug(err)
 			logger.Warningf("Connection failed to the datacenter %s", datacenter.Name)
 			continue
 		}
 		events, err := datacenter.GetEvents()
 		if err != nil {
+			logger.Debug(err)
 			logger.Warningf("Connection failed to the datacenter %s", datacenter.Name)
 			continue
 		}
 		info, err := datacenter.GetInfo()
 		if err != nil {
+			logger.Debug(err)
 			logger.Warningf("Connection failed to the datacenter %s", datacenter.Name)
 			continue
 		}
 		aggregates, err := datacenter.GetAggregates()
 		if err != nil {
+			logger.Debug(err)
 			logger.Warningf("Connection failed to the datacenter %s", datacenter.Name)
 			continue
 		}
@@ -155,12 +162,12 @@ func (d *Daemon) fetchData() {
 
 		// build datacenter
 		dc := d.buildDatacenter(&datacenter.Name, info)
-		dc.Stats["aggregates"] = len(aggregates)
-		dc.Stats["checks"] = len(checks)
-		dc.Stats["clients"] = len(clients)
-		dc.Stats["events"] = len(events)
-		dc.Stats["silenced"] = len(silenced)
-		dc.Stats["stashes"] = len(stashes)
+		dc.Metrics["aggregates"] = len(aggregates)
+		dc.Metrics["checks"] = len(checks)
+		dc.Metrics["clients"] = len(clients)
+		dc.Metrics["events"] = len(events)
+		dc.Metrics["silenced"] = len(silenced)
+		dc.Metrics["stashes"] = len(stashes)
 		d.Data.Dc = append(d.Data.Dc, dc)
 	}
 }

--- a/uchiwa/daemon/datacenters.go
+++ b/uchiwa/daemon/datacenters.go
@@ -4,9 +4,9 @@ import "github.com/sensu/uchiwa/uchiwa/structs"
 
 func (d *Daemon) buildDatacenter(name *string, info *structs.Info) *structs.Datacenter {
 	datacenter := structs.Datacenter{
-		Name:  *name,
-		Info:  *info,
-		Stats: make(map[string]int, 5),
+		Name:    *name,
+		Info:    *info,
+		Metrics: make(map[string]int, 5),
 	}
 
 	return &datacenter

--- a/uchiwa/datacenter.go
+++ b/uchiwa/datacenter.go
@@ -1,0 +1,17 @@
+package uchiwa
+
+import (
+	"fmt"
+
+	"github.com/sensu/uchiwa/uchiwa/structs"
+)
+
+func (u *Uchiwa) Datacenter(name string) (*structs.Datacenter, error) {
+	for _, dc := range u.Data.Dc {
+		if dc.Name == name {
+			return dc, nil
+		}
+	}
+
+	return nil, fmt.Errorf("")
+}

--- a/uchiwa/structs/structs.go
+++ b/uchiwa/structs/structs.go
@@ -47,9 +47,9 @@ type Data struct {
 
 // Datacenter is a structure for holding the information about a datacenter
 type Datacenter struct {
-	Name  string         `json:"name"`
-	Info  Info           `json:"info"`
-	Stats map[string]int `json:"stats"`
+	Name    string         `json:"name"`
+	Info    Info           `json:"info"`
+	Metrics map[string]int `json:"metrics"`
 }
 
 // Generic is a structure for holding a generic element
@@ -93,9 +93,19 @@ type SensuHealth struct {
 
 // Info is a structure for holding the /info API information
 type Info struct {
-	Redis     Redis     `json:"redis"`
-	Sensu     Sensu     `json:"sensu"`
-	Transport transport `json:"transport"`
+	Redis     Redis        `json:"redis"`
+	Sensu     Sensu        `json:"sensu"`
+	Servers   []InfoServer `json:"servers"`
+	Transport transport    `json:"transport"`
+}
+
+type InfoServer struct {
+	ID        string                        `json:"id"`
+	Hostname  string                        `json:"hostname"`
+	Address   string                        `json:"address"`
+	IsLeader  bool                          `json:"is_leader"`
+	Metrics   map[string]map[string]float32 `json:"metrics"`
+	Timestamp int                           `json:"timestamp"`
 }
 
 // Redis is a structure for holding the redis status


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We add a new datacenter view, accessible from the datacenters view, in order to access new information about the Sensu servers available since [Sensu 0.28](https://sensuapp.org/docs/0.28/overview/changelog.html#core-v0-28-0-changes).

The `Datacenter` structure exposed in the /datacenters endpoint has been modified; the `Stats` attribute is now called `Metrics`.

We also add additional debug information when Sensu API does not respond properly.

## Related Issue
Fixes https://github.com/sensu/uchiwa/issues/652
Depends on https://github.com/sensu/uchiwa-web/pull/145

## Motivation and Context
Display Sensu servers information

## Screenshots (if appropriate):
![screen shot 2017-03-23 at 16 07 03](https://cloud.githubusercontent.com/assets/4105580/24268322/c6704b4c-0fe3-11e7-8ede-566e6a3a07c2.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
