### PR TITLE
[enterprise] Add support for multiple LDAP servers

### DIFF
--- a/uchiwa/config/config.go
+++ b/uchiwa/config/config.go
@@ -22,12 +22,14 @@ var (
 		LogLevel: "info",
 		Refresh:  10,
 		Ldap: Ldap{
-			Port:                 389,
-			Security:             "none",
-			UserAttribute:        "sAMAccountName",
-			UserObjectClass:      "person",
-			GroupMemberAttribute: "member",
-			GroupObjectClass:     "groupOfNames",
+			LdapServer: LdapServer{
+				Port:                 389,
+				Security:             "none",
+				UserAttribute:        "sAMAccountName",
+				UserObjectClass:      "person",
+				GroupMemberAttribute: "member",
+				GroupObjectClass:     "groupOfNames",
+			},
 		},
 		Audit: Audit{
 			Level:   "default",

--- a/uchiwa/config/config_test.go
+++ b/uchiwa/config/config_test.go
@@ -163,6 +163,9 @@ func TestGetPublic(t *testing.T) {
 				LdapServer: LdapServer{
 					BindPass: "secret",
 				},
+				Servers: []LdapServer{
+					LdapServer{BindPass: "secret"},
+				},
 			},
 		},
 	}
@@ -185,6 +188,36 @@ func TestGetPublic(t *testing.T) {
 	assert.Equal(t, "*****", pubConf.Uchiwa.Github.ClientID)
 	assert.Equal(t, "*****", pubConf.Uchiwa.Github.ClientSecret)
 	assert.Equal(t, "*****", pubConf.Uchiwa.Ldap.BindPass)
+	assert.Equal(t, "*****", pubConf.Uchiwa.Ldap.Servers[0].BindPass)
+}
+
+func TestInitLdap(t *testing.T) {
+	// The default values should be applied to every LDAP server
+	conf := Config{
+		Uchiwa: GlobalConfig{
+			Ldap: Ldap{
+				Servers: []LdapServer{
+					LdapServer{Server: "10.0.0.1"},
+				},
+			},
+		},
+	}
+	initLdap(&conf.Uchiwa.Ldap)
+	assert.Equal(t, 1, len(conf.Uchiwa.Ldap.Servers))
+	assert.Equal(t, 389, conf.Uchiwa.Ldap.Servers[0].Port)
+
+	// A single LDAP server in Ldap struct should be moved to Servers struct
+	conf = Config{
+		Uchiwa: GlobalConfig{
+			Ldap: Ldap{
+				LdapServer: LdapServer{
+					Server: "10.0.0.1",
+				},
+			},
+		},
+	}
+	initLdap(&conf.Uchiwa.Ldap)
+	assert.Equal(t, 1, len(conf.Uchiwa.Ldap.Servers))
 }
 
 func TestUsersOptions(t *testing.T) {

--- a/uchiwa/config/config_test.go
+++ b/uchiwa/config/config_test.go
@@ -118,18 +118,24 @@ func TestInitUchiwa(t *testing.T) {
 			},
 		},
 	}
-	expectedConf := Ldap{
-		LdapServer: LdapServer{
-			BaseDN:      "cn=foo",
-			GroupBaseDN: "cn=foo",
-			UserBaseDN:  "cn=foo",
-			Server:      "127.0.0.1",
+	expectedLdapServers := []LdapServer{
+		LdapServer{
+			BaseDN:               "cn=foo",
+			Server:               "127.0.0.1",
+			Port:                 389,
+			GroupBaseDN:          "cn=foo",
+			GroupObjectClass:     "groupOfNames",
+			GroupMemberAttribute: "member",
+			Security:             "none",
+			UserAttribute:        "sAMAccountName",
+			UserBaseDN:           "cn=foo",
+			UserObjectClass:      "person",
 		},
 	}
 
 	uchiwa = initUchiwa(conf)
 	assert.Equal(t, "ldap", uchiwa.Auth.Driver)
-	assert.Equal(t, expectedConf, uchiwa.Ldap)
+	assert.Equal(t, expectedLdapServers, uchiwa.Ldap.Servers)
 
 	conf = GlobalConfig{Db: Db{Driver: "mysql", Scheme: "foo"}}
 	uchiwa = initUchiwa(conf)

--- a/uchiwa/config/config_test.go
+++ b/uchiwa/config/config_test.go
@@ -110,10 +110,26 @@ func TestInitUchiwa(t *testing.T) {
 	uchiwa = initUchiwa(conf)
 	assert.Equal(t, "gitlab", uchiwa.Auth.Driver)
 
-	conf = GlobalConfig{Ldap: Ldap{BaseDN: "cn=foo", Server: "127.0.0.1"}}
+	conf = GlobalConfig{
+		Ldap: Ldap{
+			LdapServer: LdapServer{
+				BaseDN: "cn=foo",
+				Server: "127.0.0.1",
+			},
+		},
+	}
+	expectedConf := Ldap{
+		LdapServer: LdapServer{
+			BaseDN:      "cn=foo",
+			GroupBaseDN: "cn=foo",
+			UserBaseDN:  "cn=foo",
+			Server:      "127.0.0.1",
+		},
+	}
+
 	uchiwa = initUchiwa(conf)
 	assert.Equal(t, "ldap", uchiwa.Auth.Driver)
-	assert.Equal(t, Ldap{BaseDN: "cn=foo", GroupBaseDN: "cn=foo", UserBaseDN: "cn=foo", Server: "127.0.0.1"}, uchiwa.Ldap)
+	assert.Equal(t, expectedConf, uchiwa.Ldap)
 
 	conf = GlobalConfig{Db: Db{Driver: "mysql", Scheme: "foo"}}
 	uchiwa = initUchiwa(conf)
@@ -143,7 +159,11 @@ func TestGetPublic(t *testing.T) {
 			Users:  []authentication.User{authentication.User{ID: 1}},
 			Db:     Db{Scheme: "foo"},
 			Github: Github{ClientID: "foo", ClientSecret: "secret"},
-			Ldap:   Ldap{BindPass: "secret"},
+			Ldap: Ldap{
+				LdapServer: LdapServer{
+					BindPass: "secret",
+				},
+			},
 		},
 	}
 

--- a/uchiwa/config/structs.go
+++ b/uchiwa/config/structs.go
@@ -79,8 +79,9 @@ type Gitlab struct {
 // Ldap struct contains the LDAP driver configuration
 type Ldap struct {
 	LdapServer
-	Debug bool
-	Roles []authentication.Role
+	Debug   bool
+	Roles   []authentication.Role
+	Servers []LdapServer
 }
 
 type LdapServer struct {

--- a/uchiwa/config/structs.go
+++ b/uchiwa/config/structs.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"crypto/tls"
+
 	"github.com/sensu/uchiwa/uchiwa/authentication"
 	"github.com/sensu/uchiwa/uchiwa/structs"
 )
@@ -97,6 +99,7 @@ type LdapServer struct {
 	GroupMemberAttribute string
 	Insecure             bool
 	Security             string
+	TLSConfig            *tls.Config
 	UserAttribute        string
 	UserBaseDN           string
 	UserObjectClass      string

--- a/uchiwa/config/structs.go
+++ b/uchiwa/config/structs.go
@@ -78,19 +78,23 @@ type Gitlab struct {
 
 // Ldap struct contains the LDAP driver configuration
 type Ldap struct {
+	LdapServer
+	Debug bool
+	Roles []authentication.Role
+}
+
+type LdapServer struct {
 	Server               string
 	Port                 int
 	BaseDN               string
 	BindUser             string
 	BindPass             string
-	Debug                bool
 	Dialect              string
 	DisableNestedGroups  bool
 	GroupBaseDN          string
 	GroupObjectClass     string
 	GroupMemberAttribute string
 	Insecure             bool
-	Roles                []authentication.Role
 	Security             string
 	UserAttribute        string
 	UserBaseDN           string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adjust the `config` package for the enterprise Console.

## Related Issue
https://github.com/sensu/sensu-enterprise-dashboard/issues/79

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
