### PR TITLE
Consider clients subscriptions when determining if a check is silenced

### DIFF
--- a/uchiwa/check.go
+++ b/uchiwa/check.go
@@ -26,7 +26,7 @@ func (u *Uchiwa) GetCheck(dc, name string) (map[string]interface{}, error) {
 	u.Mu.Lock()
 	defer u.Mu.Unlock()
 	check["dc"] = dc
-	check["silenced"], check["silenced_by"] = helpers.IsCheckSilenced(check, "", dc, u.Data.Silenced)
+	check["silenced"], check["silenced_by"] = helpers.IsCheckSilenced(check, nil, dc, u.Data.Silenced)
 
 	return check, nil
 }

--- a/uchiwa/client.go
+++ b/uchiwa/client.go
@@ -18,13 +18,14 @@ func (u *Uchiwa) buildClientHistory(client, dc string, history []interface{}) []
 		m["client"] = client
 		m["dc"] = dc
 
-		check, ok := m["last_result"].(map[string]interface{})
+		checkMap, ok := m["last_result"].(map[string]interface{})
 		if !ok {
 			logger.Warningf("Could not assert this check to a struct: %+v", m["last_result"])
 			continue
 		}
 
-		m["silenced"], m["silenced_by"] = helpers.IsCheckSilenced(check, client, dc, u.Data.Silenced)
+		clientMap := map[string]interface{}{"name": client}
+		m["silenced"], m["silenced_by"] = helpers.IsCheckSilenced(checkMap, clientMap, dc, u.Data.Silenced)
 	}
 
 	return history

--- a/uchiwa/daemon/events.go
+++ b/uchiwa/daemon/events.go
@@ -53,6 +53,6 @@ func (d *Daemon) buildEvents() {
 
 		// Determine if the check is silenced.
 		// See https://github.com/sensu/uchiwa/issues/602
-		m["silenced"], m["silenced_by"] = helpers.IsCheckSilenced(checkMap, client, dc, d.Data.Silenced)
+		m["silenced"], m["silenced_by"] = helpers.IsCheckSilenced(checkMap, clientMap, dc, d.Data.Silenced)
 	}
 }

--- a/uchiwa/helpers/helpers_test.go
+++ b/uchiwa/helpers/helpers_test.go
@@ -120,8 +120,8 @@ func TestGetMapFromInterface(t *testing.T) {
 }
 
 func TestIsCheckSilenced(t *testing.T) {
-	var check map[string]interface{}
-	var client, dc string
+	var check, client map[string]interface{}
+	var dc string
 	var silenced []interface{}
 	var isSilencedBy []string
 
@@ -130,7 +130,7 @@ func TestIsCheckSilenced(t *testing.T) {
 
 	// Not silenced
 	check = map[string]interface{}{"name": "check_cpu", "subscribers": []interface{}{"load-balancer"}}
-	client = "foo"
+	client = map[string]interface{}{"name": "foo"}
 	dc = "us-east-1"
 	isSilenced, _ = IsCheckSilenced(check, client, dc, silenced)
 	assert.False(t, isSilenced)
@@ -143,7 +143,7 @@ func TestIsCheckSilenced(t *testing.T) {
 	// Silenced check with check
 	// e.g. *:check_cpu
 	silenced = []interface{}{map[string]interface{}{"dc": "us-east-1", "id": "*:check_cpu"}}
-	isSilenced, isSilencedBy = IsCheckSilenced(check, "", dc, silenced)
+	isSilenced, isSilencedBy = IsCheckSilenced(check, nil, dc, silenced)
 	assert.True(t, isSilenced)
 	assert.Equal(t, "*:check_cpu", isSilencedBy[0])
 
@@ -191,6 +191,14 @@ func TestIsCheckSilenced(t *testing.T) {
 	isSilenced, isSilencedBy = IsCheckSilenced(check, client, dc, silenced)
 	assert.True(t, isSilenced)
 	assert.Equal(t, "*:check_cpu", isSilencedBy[0])
+
+	// Silenced check with client's subscription and check's name
+	check = map[string]interface{}{"name": "check_cpu", "subscribers": []interface{}{"dev", "us-east-1"}}
+	client = map[string]interface{}{"name": "foo", "subscriptions": []interface{}{"production", "us-east-1"}}
+	silenced = []interface{}{map[string]interface{}{"dc": "us-east-1", "id": "production:check_cpu"}}
+	isSilenced, isSilencedBy = IsCheckSilenced(check, client, dc, silenced)
+	assert.True(t, isSilenced)
+	assert.Equal(t, "production:check_cpu", isSilencedBy[0])
 }
 
 func TestInterfaceToSlice(t *testing.T) {


### PR DESCRIPTION
## Description
A check could be silenced based on the clients subscriptions and not only its own subscribers.

## Related Issue
Fixes https://github.com/sensu/uchiwa/issues/689

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
