### PR TITLE
Allow to build uchiwa packages in docker

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.8.1-alpine
+
+ENV GOARCH=amd64
+
+# Disable cgo so that binaries we build will be fully static.
+ENV CGO_ENABLED=0
+
+RUN apk add --no-cache \
+  bash \
+  build-base \
+  git \
+  libffi-dev \
+  make \
+  nodejs \
+  rpm \
+  ruby-dev \
+  ruby-rake \
+  tar && \
+  gem install rake -v "10.5.0" --no-ri --no-rdoc && \
+  gem install fpm -v "1.8.1" --no-ri --no-rdoc && \
+  rm -rf /usr/lib/ruby/gems/*/cache/* && \
+  rm -rf ~/.gem

--- a/build/tests.sh
+++ b/build/tests.sh
@@ -6,11 +6,13 @@ echo "" > coverage.txt
 
 for d in $(go list ./... | grep -v vendor); do
   race=""
-  if [ $GOARCH == "amd64" ]; then
+  # The race detector is broken on Alpine. That is #14481 (and #9918).
+  # So disable it for now.
+  if [ "${GOARCH}" = "amd64" ] && [ ! -f /etc/alpine-release ]; then
     race="-race"
   fi
 
-  go test $race -coverprofile=profile.out -covermode=atomic $d
+  go test $race -coverprofile=profile.out -covermode=atomic "$d"
   if [ -f profile.out ]; then
     cat profile.out >> coverage.txt
     rm profile.out


### PR DESCRIPTION
It's really helpful to have an ability to build uchiwa package
in docker image, without installing additional dependencies on
host system

## Description
Allow to build uchiwa package in docker

## Related Issue

## Motivation and Context
We need to have ability for simple uchiwa packaging

## How Has This Been Tested?
No changes in code itself, just additional feature with two docker commands:
* build docker image
* build package with docker image

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [+] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [+] My change requires a change to the documentation.
- [+] I have updated the documentation accordingly.
- [+] I have read the **CONTRIBUTING** document.
- [+] I have added tests to cover my changes.
- [+] All new and existing tests passed.
