### PR TITLE
Prevent makeslice: len out of range when using the response content length

### DIFF
--- a/uchiwa/sensu/request.go
+++ b/uchiwa/sensu/request.go
@@ -65,6 +65,10 @@ func (api *API) doRequest(req *http.Request) ([]byte, *http.Response, error) {
 		return nil, nil, fmt.Errorf("%v", res.Status)
 	}
 
+	if res.ContentLength < 0 {
+		return nil, nil, fmt.Errorf("unknown content length of %d", res.ContentLength)
+	}
+
 	body := make([]byte, res.ContentLength)
 	n, err := io.ReadFull(res.Body, body)
 	if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
It makes sure we validate the content length of the response before trying to read its body

## Related Issue
Closes https://github.com/sensu/uchiwa/issues/725

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
