### PR TITLE
Add Slack badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ See [uchiwa-web](https://github.com/sensu/uchiwa-web) for the AngularJS web fron
 [![codecov](https://codecov.io/gh/sensu/uchiwa/branch/master/graph/badge.svg)](https://codecov.io/gh/sensu/uchiwa)
 [![Go Report](https://goreportcard.com/badge/github.com/sensu/uchiwa)](https://goreportcard.com/report/github.com/sensu/uchiwa)
 [![Download](https://api.bintray.com/packages/palourde/uchiwa/uchiwa/images/download.svg) ](https://uchiwa.io/#/download)
+[![Join the chat at https://slack.sensu.io/](https://slack.sensu.io/badge.svg)](https://slack.sensu.io/)
 
 ![Uchiwa UI](docs/uchiwa-ui.png)
 


### PR DESCRIPTION
Adds a link to the Sensu Community slack to the readme.