### PR TITLE
Add configurable TLS config

### DIFF
--- a/uchiwa/config/structs.go
+++ b/uchiwa/config/structs.go
@@ -94,6 +94,7 @@ type Ldap struct {
 	Servers []LdapServer
 }
 
+// LdapServer contains the configuration of a specific LDAP server
 type LdapServer struct {
 	Server               string
 	Port                 int
@@ -126,8 +127,11 @@ type OIDC struct {
 
 // SSL struct contains the path the SSL certificate and key
 type SSL struct {
-	CertFile string
-	KeyFile  string
+	CertFile      string
+	KeyFile       string
+	CipherSuite   []string
+	TLSMinVersion string
+	TLSConfig     *tls.Config
 }
 
 // UsersOptions struct contains various config tweaks

--- a/uchiwa/config/tls.go
+++ b/uchiwa/config/tls.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"crypto/tls"
+	"strings"
+
+	"github.com/sensu/uchiwa/uchiwa/logger"
+)
+
+// TLSVersions contains a correspondence  map for TLS versions in config
+var TLSVersions = map[string]uint16{
+	"tls10": tls.VersionTLS10,
+	"tls11": tls.VersionTLS11,
+	"tls12": tls.VersionTLS12,
+}
+
+// defaultCipherSuite returns the default cipher suite for Uchiwa, which
+// contains the default Go cipher suite minus cipher using 3DES (SWEET32)
+func defaultCipherSuite() []uint16 {
+	return []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	}
+}
+
+// parseCipherSuite takes a list of cipher suite IDs as defined in
+// https"://golang.org/src/crypto/tls/cipher_suites.go and returns their uint16
+// equivalent
+func parseCipherSuite(ids []string) []uint16 {
+	ciphers := []uint16{}
+
+	correspondenceMap := map[string]uint16{
+		"TLS_RSA_WITH_RC4_128_SHA":                tls.TLS_RSA_WITH_RC4_128_SHA,
+		"TLS_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+		"TLS_RSA_WITH_AES_128_CBC_SHA":            tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		"TLS_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		"TLS_RSA_WITH_AES_128_CBC_SHA256":         tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+		"TLS_RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		"TLS_RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":        tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		"TLS_ECDHE_RSA_WITH_RC4_128_SHA":          tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+		"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":     tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"TvLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":  tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":    tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+	}
+
+	for _, id := range ids {
+		id = strings.ToUpper(id)
+		if cipher, ok := correspondenceMap[id]; ok {
+			ciphers = append(ciphers, cipher)
+		} else {
+			logger.Fatalf("unknown '%s' cipher", id)
+		}
+	}
+
+	return ciphers
+}

--- a/uchiwa/server.go
+++ b/uchiwa/server.go
@@ -2,6 +2,7 @@ package uchiwa
 
 import (
 	"compress/gzip"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -1381,7 +1382,12 @@ func (u *Uchiwa) WebServer(publicPath *string, auth authentication.Config) {
 	logger.Warningf("Uchiwa is now listening on %s", listen)
 
 	if u.Config.Uchiwa.SSL.CertFile != "" && u.Config.Uchiwa.SSL.KeyFile != "" {
-		logger.Fatal(http.ListenAndServeTLS(listen, u.Config.Uchiwa.SSL.CertFile, u.Config.Uchiwa.SSL.KeyFile, nil))
+		server := http.Server{
+			Addr:         listen,
+			TLSConfig:    u.Config.Uchiwa.SSL.TLSConfig,
+			TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
+		}
+		logger.Fatal(server.ListenAndServeTLS(u.Config.Uchiwa.SSL.CertFile, u.Config.Uchiwa.SSL.KeyFile))
 	}
 
 	logger.Fatal(http.ListenAndServe(listen, nil))


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon.plourde@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
The TLS cipher suite and TLS minimal version are now configurable.

Additionally, the `TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA` & `TLS_RSA_WITH_3DES_EDE_CBC_SHA` ciphers have been removed from the default suite.

## Related Issue
Closes https://github.com/sensu/uchiwa/issues/688

## Motivation and Context
Fix SWEET32 vulnerability

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
