### PR TITLE
Add Dump debugs and revert HTTP optimization when Transfer-Encoding i…

### DIFF
--- a/uchiwa/helpers/helpers.go
+++ b/uchiwa/helpers/helpers.go
@@ -14,6 +14,17 @@ import (
 	"github.com/sensu/uchiwa/uchiwa/structs"
 )
 
+// return true if String in Slice, false otherwise
+func StringInSlice(a string, list []string) bool {
+    for _, b := range list {
+        if b == a {
+            return true
+        }
+    }
+    return false
+}
+
+
 // BuildClientsMetrics builds the metrics for the events
 func BuildClientsMetrics(clients *[]interface{}) *structs.StatusMetrics {
 	metrics := structs.StatusMetrics{}


### PR DESCRIPTION
…s chunked
## Description
If API server is behind nginx proxy (for https encryption), http/1.1 might be using Transfer-Encoding chunked with Content-Length = -1. reverting to old ioutil method only for cases where Content-Length = -1 and Tansfer-Encoding contains chunked

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#751 

## Motivation and Context
Solve issue of API server behind nginx https reverse proxy

## How Has This Been Tested?
own setup

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
