### PR TITLE
Do not serialize the TLS config

### DIFF
--- a/uchiwa/config/structs.go
+++ b/uchiwa/config/structs.go
@@ -108,7 +108,7 @@ type LdapServer struct {
 	GroupMemberAttribute string
 	Insecure             bool
 	Security             string
-	TLSConfig            *tls.Config
+	TLSConfig            *tls.Config `json:"-"`
 	UserAttribute        string
 	UserBaseDN           string
 	UserObjectClass      string
@@ -131,7 +131,7 @@ type SSL struct {
 	KeyFile       string
 	CipherSuite   []string
 	TLSMinVersion string
-	TLSConfig     *tls.Config
+	TLSConfig     *tls.Config `json:"-"`
 }
 
 // UsersOptions struct contains various config tweaks


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon.plourde@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
It prevents the `unsupported type: func() time.Time` error when serializing the config to JSON.

## Related Issue
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
