### PR TITLE
Validate both check & client subscriptions when silencing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: true
 language: go
 go:
-  - 1.8
+  - 1.9
 env:
   matrix:
     - TRAVIS_GOOS=linux TRAVIS_GOARCH=386
@@ -10,7 +10,6 @@ env:
     - AWS_REGION=us-west-2
     - secure: "AbBK9m/ERyL2RzTd2+IwYkPxW+gnQSXB83AlcvgRNfGF+Y+zaDDZ4PaKDdl0hfKmsIwzvxpTn/t3pwN/UXYCdcKVzQFHmqhpgL1Vb6D6GV0tzSE87L9jod+5H5zFo4MufxIV2WpiV2yErJh+pl24l3kBuoJc7Ot3D3gj3tjLSCU="
     - secure: "dfwJP2lOpCJxQ23ZiLOlDvuCvpwQOATE+U3Xgwwor7gqyoCMxqEdtSlVyt3PLx+LV1kWasJWuJ6pmrPplhk6CYXk/bQP9DNIJgnKiJdorg1/sxz/w2/KtuzizT+Kru+ZJVVgBcD8T1dTNFnFsPYtTrS/UdFyJ1M7gD+U7+QpuhI="
-
 before_install:
   - gem install rake -v "10.5.0"
   - gem install fpm -v "1.8.1"
@@ -18,10 +17,6 @@ before_install:
   # Workaround for https://github.com/travis-ci/travis-ci/issues/6126
   - export GOOS=$TRAVIS_GOOS
   - export GOARCH=$TRAVIS_GOARCH
-  # RPM signing
-  - pip install --user awscli
-  - export PATH=$PATH:$HOME/.local/bin
-  - ./build/setup-gpg
 script:
   - "./build/travis.sh"
 deploy:

--- a/build/travis.sh
+++ b/build/travis.sh
@@ -21,6 +21,11 @@ if [ "$(git describe --tags --exact-match "$COMMIT")" ]; then
   echo "======================== Running tests"
   GOARCH=$GOARCH ./build/tests.sh
 
+  echo "======================== Prepare RPM signing"
+   pip install --user awscli
+  export PATH=$PATH:$HOME/.local/bin
+  build/setup-gpg
+
   echo "======================== Building the packages"
   PACKAGE_VERSION=$PACKAGE_VERSION BUILD_NUMBER=$BUILD_NUMBER \
   GOOS=$GOOS GOARCH=$GOARCH \

--- a/build/travis.sh
+++ b/build/travis.sh
@@ -22,9 +22,9 @@ if [ "$(git describe --tags --exact-match "$COMMIT")" ]; then
   GOARCH=$GOARCH ./build/tests.sh
 
   echo "======================== Prepare RPM signing"
-   pip install --user awscli
+  pip install --user awscli
   export PATH=$PATH:$HOME/.local/bin
-  build/setup-gpg
+  ./build/setup-gpg
 
   echo "======================== Building the packages"
   PACKAGE_VERSION=$PACKAGE_VERSION BUILD_NUMBER=$BUILD_NUMBER \

--- a/uchiwa/client_test.go
+++ b/uchiwa/client_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestBuildClientHistory(t *testing.T) {
-	var client, dc string
+	var dc string
 	var status float64
 	const Critical float64 = 2.0
 	const Warning float64 = 1.0
@@ -25,14 +25,13 @@ func TestBuildClientHistory(t *testing.T) {
 		map[string]interface{}{"check": "cpu", "client": "qux", "dc": "us-west-1", "occurrences": 10, "output": "CRITICAL", "status": Critical},
 	}
 
-	client = "qux"
+	client := map[string]interface{}{"name": "qux"}
 	dc = "us-east-1"
 	status = Success
 	history = []interface{}{map[string]interface{}{"check": "cpu", "last_result": map[string]interface{}{"command": "cpu.rb", "status": status}, "last_status": status}}
 	expectedHistory = []interface{}{map[string]interface{}{"check": "cpu", "client": "qux", "dc": "us-east-1", "last_result": map[string]interface{}{"command": "cpu.rb", "status": status}, "last_status": status, "silenced": false, "silenced_by": []string(nil)}}
 	result := u.buildClientHistory(client, dc, history)
 	assert.Equal(t, expectedHistory, result)
-
 }
 
 func TestFindClient(t *testing.T) {

--- a/uchiwa/helpers/helpers.go
+++ b/uchiwa/helpers/helpers.go
@@ -236,8 +236,7 @@ func InterfaceToString(i []interface{}) []string {
 // Returns true if the check is silenced and a slice of silence entries IDs
 func IsCheckSilenced(check, client map[string]interface{}, dc string, silenced []interface{}) (bool, []string) {
 	var isSilenced bool
-	var isSilencedBy []string
-	var subscribers []interface{}
+	var commonSubscriptions, isSilencedBy, subscribers, subscriptions []string
 
 	if dc == "" || len(silenced) == 0 {
 		return false, isSilencedBy
@@ -253,18 +252,28 @@ func IsCheckSilenced(check, client map[string]interface{}, dc string, silenced [
 		clientName = ""
 	}
 
+	// Retrieve the check subscribers
 	if check["subscribers"] != nil {
-		subscribers, ok = check["subscribers"].([]interface{})
+		s, ok := check["subscribers"].([]interface{})
 		if !ok {
 			return false, isSilencedBy
 		}
+		subscribers = InterfaceToString(s)
 	}
 
+	// Retrieve the client subscriptions
 	if client["subscriptions"] != nil {
-		subscriptions, ok := client["subscriptions"].([]interface{})
-		if ok {
-			// Add the client subscriptions to the subscribers slice
-			subscribers = append(subscribers, subscriptions...)
+		s, ok := client["subscriptions"].([]interface{})
+		if !ok {
+			return false, isSilencedBy
+		}
+		subscriptions = InterfaceToString(s)
+	}
+
+	// Get the subscriptions both check and client have in common
+	for _, subscriber := range subscribers {
+		if IsStringInArray(subscriber, subscriptions) {
+			commonSubscriptions = append(commonSubscriptions, subscriber)
 		}
 	}
 
@@ -300,8 +309,7 @@ func IsCheckSilenced(check, client map[string]interface{}, dc string, silenced [
 			continue
 		}
 
-		for _, s := range subscribers {
-			subscription := s.(string)
+		for _, subscription := range commonSubscriptions {
 			// Subscription (e.g. load-balancer:* )
 			if m["id"] == fmt.Sprintf("%s:*", subscription) {
 				isSilenced = true

--- a/uchiwa/helpers/helpers_test.go
+++ b/uchiwa/helpers/helpers_test.go
@@ -130,7 +130,7 @@ func TestIsCheckSilenced(t *testing.T) {
 
 	// Not silenced
 	check = map[string]interface{}{"name": "check_cpu", "subscribers": []interface{}{"load-balancer"}}
-	client = map[string]interface{}{"name": "foo"}
+	client = map[string]interface{}{"name": "foo", "subscriptions": []interface{}{"client:foo", "load-balancer"}}
 	dc = "us-east-1"
 	isSilenced, _ = IsCheckSilenced(check, client, dc, silenced)
 	assert.False(t, isSilenced)
@@ -143,7 +143,7 @@ func TestIsCheckSilenced(t *testing.T) {
 	// Silenced check with check
 	// e.g. *:check_cpu
 	silenced = []interface{}{map[string]interface{}{"dc": "us-east-1", "id": "*:check_cpu"}}
-	isSilenced, isSilencedBy = IsCheckSilenced(check, nil, dc, silenced)
+	isSilenced, isSilencedBy = IsCheckSilenced(check, client, dc, silenced)
 	assert.True(t, isSilenced)
 	assert.Equal(t, "*:check_cpu", isSilencedBy[0])
 
@@ -193,12 +193,27 @@ func TestIsCheckSilenced(t *testing.T) {
 	assert.Equal(t, "*:check_cpu", isSilencedBy[0])
 
 	// Silenced check with client's subscription and check's name
-	check = map[string]interface{}{"name": "check_cpu", "subscribers": []interface{}{"dev", "us-east-1"}}
+	check = map[string]interface{}{"name": "check_cpu", "subscribers": []interface{}{"production", "us-east-1"}}
 	client = map[string]interface{}{"name": "foo", "subscriptions": []interface{}{"production", "us-east-1"}}
 	silenced = []interface{}{map[string]interface{}{"dc": "us-east-1", "id": "production:check_cpu"}}
 	isSilenced, isSilencedBy = IsCheckSilenced(check, client, dc, silenced)
 	assert.True(t, isSilenced)
 	assert.Equal(t, "production:check_cpu", isSilencedBy[0])
+
+	// Check and client do not share a common subscription
+	// https://github.com/sensu/uchiwa/issues/755
+	check = map[string]interface{}{"name": "check_foo", "subscribers": []interface{}{"foo", "bar", "baz"}}
+	client = map[string]interface{}{"name": "foo", "subscriptions": []interface{}{"bar"}}
+	silenced = []interface{}{map[string]interface{}{"dc": "us-east-1", "id": "foo:check_foo"}}
+	isSilenced, _ = IsCheckSilenced(check, client, dc, silenced)
+	assert.False(t, isSilenced)
+
+	// Check and client do share a common subscription
+	check = map[string]interface{}{"name": "check_foo", "subscribers": []interface{}{"foo", "bar", "baz"}}
+	client = map[string]interface{}{"name": "foo", "subscriptions": []interface{}{"bar"}}
+	silenced = []interface{}{map[string]interface{}{"dc": "us-east-1", "id": "bar:check_foo"}}
+	isSilenced, _ = IsCheckSilenced(check, client, dc, silenced)
+	assert.True(t, isSilenced)
 }
 
 func TestInterfaceToSlice(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When we determine if a check is silenced, we need to ensure that the client is actually subscribed to that check!

## Related Issue
Closes https://github.com/sensu/uchiwa/issues/755

## How Has This Been Tested?
Added specific unit test for that case

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
