### PR TITLE
Fix logrotate config permissions

### DIFF
--- a/build/pkg_scripts/deb/postinst
+++ b/build/pkg_scripts/deb/postinst
@@ -26,9 +26,14 @@ create_uchiwa_user_group() {
     fi
 }
 
+fix_logrotate_permissions() {
+    chmod 644 /etc/logrotate.d/uchiwa
+}
+
 case "$1" in
     configure)
         create_uchiwa_user_group
+        fix_logrotate_permissions
         ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/build/pkg_scripts/rpm/post
+++ b/build/pkg_scripts/rpm/post
@@ -4,4 +4,6 @@
 if [ $1 -eq 1 ]; then
     chkconfig --add uchiwa
     chkconfig uchiwa off
+    chmod 644 /etc/logrotate.d/uchiwa
+}
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ensures the logrotate config permissions are `644` after installation.

## Related Issue
Closes https://github.com/sensu/uchiwa/issues/757

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
