### PR TITLE
Fix syntax error in RPM post script

### DIFF
--- a/build/pkg_scripts/rpm/post
+++ b/build/pkg_scripts/rpm/post
@@ -5,5 +5,4 @@ if [ $1 -eq 1 ]; then
     chkconfig --add uchiwa
     chkconfig uchiwa off
     chmod 644 /etc/logrotate.d/uchiwa
-}
 fi


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon.plourde@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
It fixes a bug when installation 1.1.3-1 RPM packages

## Related Issue
Closes https://github.com/sensu/uchiwa/issues/760
