### PR TITLE
Fix for only one silenced entry showing up

### DIFF
--- a/uchiwa/daemon/daemon.go
+++ b/uchiwa/daemon/daemon.go
@@ -236,7 +236,7 @@ func (d *DatacenterSnapshotFetcher) fetchSilenced() {
 
 	for _, v := range silenced {
 		setDc(v, d.datacenter.Name)
-		d.snapshot.Silenced = append(d.snapshot.Stashes, v)
+		d.snapshot.Silenced = append(d.snapshot.Silenced, v)
 	}
 
 	d.mutex.Unlock()


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## Description
Fixes a bug where a maximum of one silenced entry will ever appear.

## Related Issue
Fixes https://github.com/sensu/uchiwa/issues/785

## Motivation and Context
N/A

## How Has This Been Tested?
Tested locally. More than one silenced entry will now appear.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
