### PR TITLE
update docs.uchiwa.io links to use new paths on docs.sensu.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ See [uchiwa-web](https://github.com/sensu/uchiwa-web) for the AngularJS web fron
 ![Uchiwa UI](docs/uchiwa-ui.png)
 
 ## Installation
-See [Uchiwa Docs](https://docs.uchiwa.io/getting-started/installation/).
+See [Uchiwa Docs](https://docs.sensu.io/uchiwa/latest/getting-started/installation/).
 
 ## Configuration
-See [Uchiwa Docs](https://docs.uchiwa.io/getting-started/configuration/).
+See [Uchiwa Docs](https://docs.sensu.io/uchiwa/latest/getting-started/configuration/).
 
 ## Contributing
-See [Uchiwa Docs](https://docs.uchiwa.io/contributing/).
+See [Uchiwa Docs](https://docs.sensu.io/uchiwa/latest/contributing/).
 
 ## Credits
 * Author & Maintainer: [Simon Plourde][author]


### PR DESCRIPTION
## Description

Update links in the README.md to reflect new documentation site

## Related Issue

Closes #790 

## Motivation and Context

We merged the Uchiwa documentation into the sensu-docs project, which broke these links. It is good to fix broken links.

## How Has This Been Tested?

Markdown preview looks good.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.