### PR TITLE
Add client invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.4.0 (TBD)
+#### Features
+- Add support for client invalidation - [PR #]()
+
 ### 1.3.1 (2018-06-11)
 #### Bug Fixes
 - Fix segfault on unresponsive APIs - [PR #787](https://github.com/sensu/uchiwa/pull/787)

--- a/uchiwa/client.go
+++ b/uchiwa/client.go
@@ -31,14 +31,14 @@ func (u *Uchiwa) buildClientHistory(client map[string]interface{}, dc string, hi
 }
 
 // DeleteClient send a DELETE request to the /clients/*client* endpoint in order to delete a client
-func (u *Uchiwa) DeleteClient(dc, name string) error {
+func (u *Uchiwa) DeleteClient(dc, name, invalidate, expire string) error {
 	api, err := getAPI(u.Datacenters, dc)
 	if err != nil {
 		logger.Warning(err)
 		return err
 	}
 
-	err = api.DeleteClient(name)
+	err = api.DeleteClient(name, invalidate, expire)
 	if err != nil {
 		logger.Warning(err)
 		return err

--- a/uchiwa/sensu/clients.go
+++ b/uchiwa/sensu/clients.go
@@ -6,8 +6,15 @@ import (
 )
 
 // DeleteClient deletes a client using its name
-func (s *Sensu) DeleteClient(client string) error {
-	return s.delete(fmt.Sprintf("clients/%s", client))
+func (s *Sensu) DeleteClient(client, invalidate, expire string) error {
+	url := fmt.Sprintf("clients/%s", client)
+	if invalidate == "true" {
+		url = fmt.Sprintf("%s?invalidate=true", url)
+		if expire != "" {
+			url = fmt.Sprintf("%s&invalidate_expire=%s", url, expire)
+		}
+	}
+	return s.delete(url)
 }
 
 // GetClients returns a slice of all clients

--- a/uchiwa/server.go
+++ b/uchiwa/server.go
@@ -438,7 +438,10 @@ func (u *Uchiwa) clientHandler(w http.ResponseWriter, r *http.Request) {
 
 	// DELETE on /clients/:client
 	if r.Method == http.MethodDelete {
-		err := u.DeleteClient(dc, name)
+		invalidate := r.URL.Query().Get("invalidate")
+		expire := r.URL.Query().Get("invalidate_expire")
+
+		err := u.DeleteClient(dc, name, invalidate, expire)
 		if err != nil {
 			http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon.plourde@gmail.com>

## Description
It adds support for client invalidation when deleting a single or multiple clients.

## Related Issue
Requires https://github.com/sensu/uchiwa-web/pull/24
Closes https://github.com/sensu/sensu-enterprise-dashboard/issues/132

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
