### PR TITLE
Support marking APIs as healthy/unhealthy

### DIFF
--- a/uchiwa/daemon/helpers.go
+++ b/uchiwa/daemon/helpers.go
@@ -18,7 +18,7 @@ func FindDcFromInterface(data interface{}, datacenters *[]sensu.Sensu) (*sensu.S
 
 	id := m["dc"].(string)
 	if id == "" {
-		logger.Warningf("The received interface does not contain any datacenter information: ", data)
+		logger.Warningf("The received interface does not contain any datacenter information: %+v", data)
 		return nil, nil, errors.New("could not determine the datacenter")
 	}
 

--- a/uchiwa/daemon/subscriptions.go
+++ b/uchiwa/daemon/subscriptions.go
@@ -14,7 +14,7 @@ func (d *Daemon) BuildSubscriptions() {
 		var generic structs.GenericClient
 		err := mapstructure.Decode(client, &generic)
 		if err != nil {
-			logger.Debug("%s", err)
+			logger.Debugf("%s", err)
 			continue
 		}
 

--- a/uchiwa/main.go
+++ b/uchiwa/main.go
@@ -70,6 +70,7 @@ OUTER:
 			Tracing:           api.Advanced.Tracing,
 			URL:               api.URL,
 			User:              api.User,
+			Healthy:           true,
 		}
 		dc.Init()
 

--- a/uchiwa/sensu/info.go
+++ b/uchiwa/sensu/info.go
@@ -22,3 +22,20 @@ func (s *Sensu) GetInfo() (*structs.Info, error) {
 
 	return &info, nil
 }
+
+// GetInfo returns a pointer to a structs.Info struct containing the
+// Sensu version and the transport and Redis connection information
+func (s *Sensu) GetInfoFromAPI(i int) (*structs.Info, error) {
+	api := &s.APIs[i]
+	body, _, err := s.getBytesFromAPI(api, "info")
+	if err != nil {
+		return nil, err
+	}
+
+	var info structs.Info
+	if err := json.Unmarshal(body, &info); err != nil {
+		return nil, fmt.Errorf("Parsing JSON-encoded response body: %v", err)
+	}
+
+	return &info, nil
+}

--- a/uchiwa/sensu/sensu.go
+++ b/uchiwa/sensu/sensu.go
@@ -34,6 +34,7 @@ type API struct {
 	URL               string
 	User              string
 	Healthy           bool
+	CheckingHealth    bool
 
 	Client http.Client
 }

--- a/uchiwa/sensu/sensu.go
+++ b/uchiwa/sensu/sensu.go
@@ -33,6 +33,7 @@ type API struct {
 	Tracing           bool
 	URL               string
 	User              string
+	Healthy           bool
 
 	Client http.Client
 }


### PR DESCRIPTION
## Description
Adds the ability to mark an API as healthy/unhealthy. Uchiwa will only make requests to APIs marked as healthy. APIs marked as unhealthy will be watched be a goroutine and marked as healthy once they respond with an HTTP 2xx error.

## Related Issue
Fixes #811.

## Motivation and Context
See #811.

## How Has This Been Tested?
I've tested with the following configuration:

```
{
  "sensu": [
    {
      "name": "Site 1",
      "host": "127.0.0.1",
      "port": 4567
    },
    {
      "name": "Site 2",
      "host": "127.0.0.1",
      "port": 4567
    },
    {
      "name": "Site 2",
      "host": "10.0.1.11",
      "port": 4567
    }
  ],
  "uchiwa": {
    "host": "0.0.0.0",
    "port": 3000,
      "refresh": 5,
      "loglevel": "warn"
  }
}
```

I've tested Uchiwa with one or both APIs down, one API up and one API down, and then starting the APIs that were down to see APIs marked as healthy.

## Screenshots (if appropriate):
![screen shot 2019-02-25 at 3 43 05 pm](https://user-images.githubusercontent.com/120659/53376702-2e465080-3914-11e9-90f4-762bc47284af.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
